### PR TITLE
Fix Appstream warnings

### DIFF
--- a/patches/appstream2.patch
+++ b/patches/appstream2.patch
@@ -1,4 +1,5 @@
-From a71caff10ad8443663e6a841a3f55c99c1153249 Mon Sep 17 00:00:00 2001
+From a95b0a8e3ca30f059ffa9e908e88ac026cd1d71b Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Matthias=20Mail=C3=A4nder?=
 Date: Sun, 10 Nov 2024 23:53:34 +0100
 Subject: [PATCH] Adhere to AppStream specification.
 
@@ -6,9 +7,9 @@ Subject: [PATCH] Adhere to AppStream specification.
  cutepeaks.pro                                       |   2 +-
  ...epeaks.png => io.github.labsquare.CutePeaks.png} | Bin
  ...desktop => io.github.labsquare.CutePeaks.desktop |   2 +-
- io.github.labsquare.CutePeaks.metainfo.xml          |   7 +++++--
+ io.github.labsquare.CutePeaks.metainfo.xml          |   9 +++++++--
  src/src.pro                                         |   4 ++--
- 5 files changed, 9 insertions(+), 6 deletions(-)
+ 5 files changed, 11 insertions(+), 6 deletions(-)
  rename icon/256/{cutepeaks.png => io.github.labsquare.CutePeaks.png} (100%)
  rename cutepeaks.desktop => io.github.labsquare.CutePeaks.desktop (81%)
 
@@ -45,7 +46,7 @@ index 759636f..a89f42f 100644
  Terminal=false
  Categories=Science;Biology;Qt;
 diff --git a/io.github.labsquare.CutePeaks.metainfo.xml b/io.github.labsquare.CutePeaks.metainfo.xml
-index e55a93f..1145633 100644
+index e55a93f..58d441b 100644
 --- a/io.github.labsquare.CutePeaks.metainfo.xml
 +++ b/io.github.labsquare.CutePeaks.metainfo.xml
 @@ -3,8 +3,10 @@
@@ -61,9 +62,19 @@ index e55a93f..1145633 100644
    <metadata_license>CC0-1.0</metadata_license>
    <project_license>GPL-3.0+</project_license>
    <description>
-@@ -29,4 +31,5 @@
+@@ -13,6 +15,7 @@
+   <screenshots>
+     <screenshot type="default">
+       <image type="source">https://raw.githubusercontent.com/labsquare/CutePeaks/master/cutepeaks.gif</image>
++      <caption>Searching for a sequence pattern.</caption>
+     </screenshot>
+   </screenshots>
+   <releases>
+@@ -28,5 +31,7 @@
+   </releases>
    <url type="homepage">https://labsquare.github.io/CutePeaks/</url>
    <url type="bugtracker">https://github.com/labsquare/CutePeaks/issues</url>
++  <url type="vcs-browser">https://github.com/labsquare/CutePeaks/</url>
    <content_rating type="oars-1.1"/>
 +  <launchable type="desktop-id">io.github.labsquare.CutePeaks.desktop</launchable>
  </component>


### PR DESCRIPTION
I updated https://github.com/labsquare/CutePeaks/pull/79 to silence https://docs.flathub.org/docs/for-app-authors/linter#appstream-missing-vcs-browser-url and https://docs.flathub.org/docs/for-app-authors/linter#appstream-screenshot-missing-caption